### PR TITLE
Unity 5.1.0 Fix

### DIFF
--- a/unity/Tiled2Unity/Scripts/Editor/ImportTiled2Unity.Mesh.cs
+++ b/unity/Tiled2Unity/Scripts/Editor/ImportTiled2Unity.Mesh.cs
@@ -214,11 +214,7 @@ namespace Tiled2Unity
                 float width = ImportUtils.GetAttributeAsFloat(xmlBoxCollider2D, "width");
                 float height = ImportUtils.GetAttributeAsFloat(xmlBoxCollider2D, "height");
                 collider.size = new Vector2(width, height);
-#if UNITY_5_0
                 collider.offset = new Vector2(width * 0.5f, -height * 0.5f);
-#else
-                collider.center = new Vector2(width * 0.5f, -height * 0.5f);
-#endif
             }
 
             // Circle colliders
@@ -228,11 +224,7 @@ namespace Tiled2Unity
                 collider.isTrigger = isTrigger;
                 float radius = ImportUtils.GetAttributeAsFloat(xmlCircleCollider2D, "radius");
                 collider.radius = radius;
-#if UNITY_5_0
                 collider.offset = new Vector2(radius, -radius);
-#else
-                collider.center = new Vector2(radius, -radius);
-#endif
             }
 
             // Edge colliders

--- a/unity/Tiled2Unity/Scripts/Editor/TiledAssetPostProcessor.cs
+++ b/unity/Tiled2Unity/Scripts/Editor/TiledAssetPostProcessor.cs
@@ -101,11 +101,7 @@ namespace Tiled2Unity
 
                 // Also, no shadows
                 mr.receiveShadows = false;
-#if UNITY_5_0
                 mr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
-#else
-                mr.castShadows = false;
-#endif
             }
         }
 


### PR DESCRIPTION
Unity 5.1.0 has deprecated some methods that were in the Unity 5.0 release. These commits simply fix those so people don't have to manually change them.

Specifically, they are:
`UnityEngine.Collider2D.center` - In `BoxCollider2D` and `CircleCollider2D`
`UnityEngine.MeshRenderer.castShadows`