### PR TITLE
Improved TileAnimator update routine

### DIFF
--- a/unity/Tiled2Unity/Scripts/Runtime/TileAnimator.cs
+++ b/unity/Tiled2Unity/Scripts/Runtime/TileAnimator.cs
@@ -29,10 +29,10 @@ namespace Tiled2Unity
 
 		private MeshRenderer renderer;
 
-		private void Awake() 
-		{
-			renderer = this.GetComponent<MeshRenderer>();
-		}
+        private void Awake() 
+        {
+            renderer = this.GetComponent<MeshRenderer>();
+        }
 
         private void Start()
         {
@@ -54,7 +54,7 @@ namespace Tiled2Unity
                 this.timer -= this.TotalAnimationTime;
             }
 
-			renderer.enabled = timer >= this.StartTime && timer < (this.StartTime + this.Duration);
+            renderer.enabled = timer >= this.StartTime && timer < (this.StartTime + this.Duration);
         }
 
     }

--- a/unity/Tiled2Unity/Scripts/Runtime/TileAnimator.cs
+++ b/unity/Tiled2Unity/Scripts/Runtime/TileAnimator.cs
@@ -27,6 +27,13 @@ namespace Tiled2Unity
 
         private float timer = 0;
 
+		private MeshRenderer renderer;
+
+		private void Awake() 
+		{
+			renderer = this.GetComponent<MeshRenderer>();
+		}
+
         private void Start()
         {
 #if T2U_USE_ASSERTIONS
@@ -47,27 +54,7 @@ namespace Tiled2Unity
                 this.timer -= this.TotalAnimationTime;
             }
 
-            // Should our mesh be rendered or not?
-            MeshRenderer renderer = this.gameObject.GetComponent<MeshRenderer>();
-            bool isEnabled = renderer.enabled;
-
-            if (timer >= this.StartTime && timer < (this.StartTime + this.Duration))
-            {
-                // Our mesh should be visible at this time
-                if (!isEnabled)
-                {
-                    renderer.enabled = true;
-                }
-            }
-            else
-            {
-                // Mesh should not be visible at this time
-                if (isEnabled)
-                {
-                    renderer.enabled = false;
-                }
-            }
-
+			renderer.enabled = timer >= this.StartTime && timer < (this.StartTime + this.Duration);
         }
 
     }

--- a/unity/Tiled2Unity/Scripts/Runtime/TileAnimator.cs
+++ b/unity/Tiled2Unity/Scripts/Runtime/TileAnimator.cs
@@ -27,7 +27,7 @@ namespace Tiled2Unity
 
         private float timer = 0;
 
-		private MeshRenderer renderer;
+        private MeshRenderer renderer;
 
         private void Awake() 
         {


### PR DESCRIPTION
This chages are intended to simplify the code on TileAnimator and also improve performance of the update routine.

Doing getComponent<T> is a costly operation that should avoid doing it on update , the code should cache that reference.

And the last change is to avoid using an if , the whole branching can be done with a single assign to the renderer.enabled variable.