### PR TITLE
attach custom props from objecttypes.xml to generated collision layers

### DIFF
--- a/tool/Tiled2Unity/Tiled2UnityLib/ExportClasses/TiledMapExporter.Prefab.cs
+++ b/tool/Tiled2Unity/Tiled2UnityLib/ExportClasses/TiledMapExporter.Prefab.cs
@@ -122,6 +122,8 @@ namespace Tiled2Unity
                         foreach (var collisionLayer in layer.CollisionLayers)
                         {
                             var collisionElements = CreateCollisionElementForLayer(collisionLayer);
+                            AssignUnityProperties(collisionLayer, collisionElements, PrefabContext.TiledLayer);
+                            AssignTiledProperties(collisionLayer, collisionElements);
                             layerElement.Add(collisionElements);
                         }
                     }

--- a/tool/Tiled2Unity/Tiled2UnityLib/TmxClasses/TmxHelper.cs
+++ b/tool/Tiled2Unity/Tiled2UnityLib/TmxClasses/TmxHelper.cs
@@ -147,6 +147,10 @@ namespace Tiled2Unity
             {
                 TmxObject tmxObject = hasProperties as TmxObject;
                 objectTypeName = tmxObject.Type;
+            } else if (hasProperties is TmxLayer)
+            {
+                TmxLayer tmxLayer = hasProperties as TmxLayer;
+                objectTypeName = tmxLayer.Name;
             }
 
             // If an object type has been found then copy over all the default values for properties


### PR DESCRIPTION
With this addition I was able to attach objecttypes.xml properties to the generated collision layers, but due to other problems with 1.0.7.0 I was unable to use the generated maps. 

The reason for doing this was to allow me to use the CustomImporter to use HandleCustomProperties on the generated collision layers.